### PR TITLE
Fix HDMI/DP Audio Output

### DIFF
--- a/EFI - Big Sur/OC/Config.plist
+++ b/EFI - Big Sur/OC/Config.plist
@@ -1225,7 +1225,7 @@
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con1-alldata</key>
-				<data>AQUSAAAEAACHAAAA</data>
+				<data>AQUSAAAIAACHAAAA</data>
 				<key>framebuffer-con1-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con2-alldata</key>

--- a/EFI - Catalina/OC/Config.plist
+++ b/EFI - Catalina/OC/Config.plist
@@ -1225,7 +1225,7 @@
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con1-alldata</key>
-				<data>AQUSAAAEAACHAAAA</data>
+				<data>AQUSAAAIAACHAAAA</data>
 				<key>framebuffer-con1-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con2-alldata</key>

--- a/EFI - Heliport/OC/Config.plist
+++ b/EFI - Heliport/OC/Config.plist
@@ -1225,7 +1225,7 @@
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con1-alldata</key>
-				<data>AQUSAAAEAACHAAAA</data>
+				<data>AQUSAAAIAACHAAAA</data>
 				<key>framebuffer-con1-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con2-alldata</key>

--- a/EFI - Monterey/OC/Config.plist
+++ b/EFI - Monterey/OC/Config.plist
@@ -1225,7 +1225,7 @@
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con1-alldata</key>
-				<data>AQUSAAAEAACHAAAA</data>
+				<data>AQUSAAAIAACHAAAA</data>
 				<key>framebuffer-con1-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con2-alldata</key>


### PR DESCRIPTION
This PR enables audio output on the Mini-DP port of T440p by changing the connector type from DP to HDMI. [reference](https://dortania.github.io/OpenCore-Post-Install/gpu-patching/intel-patching/connector.html) Previously, only video output is supported.

It seems like macOS somehow requires the port to be HDMI to output audio to it. 

Tested on T440p Monetary 12.4.